### PR TITLE
Add f32/f64 datatype impls for SGL/DBL registers

### DIFF
--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -11,7 +11,7 @@ struct TestCluster {
     u: u16,
 }
 
-fn test_case<T: PartialEq + std::fmt::Debug>(test_case_name: &str, expected: T, actual: T) {
+fn test_case<T: PartialEq + std::fmt::Debug>(test_case_name: &str, actual: T, expected: T) {
     eprint!("{}...", test_case_name);
     if expected != actual {
         eprintln!(
@@ -70,7 +70,9 @@ fn main() -> Result<(), ni_fpga::Error> {
         0b1111111111111110111111001111100011110000111000001100000010000000,
     );
 
-    // TODO: Test SGL @ 98336
+    #[allow(clippy::approx_constant)]
+    test_case("read SGL", session.read::<f32>(98336)?, 3.14);
+
     // TODO: Test unsigned FXP @ 98342
     // TODO: Test signed FXP @ 98346
 

--- a/ni-fpga/Cargo.toml
+++ b/ni-fpga/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ni-fpga"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Connor Worley <connorbworley@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/ni-fpga/src/datatype.rs
+++ b/ni-fpga/src/datatype.rs
@@ -155,6 +155,30 @@ impl Datatype for i64 {
     }
 }
 
+impl Datatype for f32 {
+    const SIZE_IN_BITS: usize = 32;
+
+    fn pack(fpga_bits: &mut FpgaBits, data: &Self) -> Result<(), Error> {
+        u32::pack(fpga_bits, &data.to_bits())
+    }
+
+    fn unpack(fpga_bits: &FpgaBits) -> Result<Self, Error> {
+        Ok(Self::from_bits(u32::unpack(fpga_bits)?))
+    }
+}
+
+impl Datatype for f64 {
+    const SIZE_IN_BITS: usize = 64;
+
+    fn pack(fpga_bits: &mut FpgaBits, data: &Self) -> Result<(), Error> {
+        u64::pack(fpga_bits, &data.to_bits())
+    }
+
+    fn unpack(fpga_bits: &FpgaBits) -> Result<Self, Error> {
+        Ok(Self::from_bits(u64::unpack(fpga_bits)?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,7 +205,6 @@ mod tests {
         Ok(())
     }
 
-    // Test against some random constants
     #[test]
     fn test_u8() -> Result<(), Error> {
         round_trip_test(&0b00000001u8)?;
@@ -225,6 +248,17 @@ mod tests {
     #[allow(overflowing_literals)]
     fn test_i64() -> Result<(), Error> {
         round_trip_test(&0b1111111111111110111111001111100011110000111000001100000010000000i64)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_f32() -> Result<(), Error> {
+        round_trip_test(&3.14f32)?;
+        Ok(())
+    }
+    #[test]
+    fn test_f64() -> Result<(), Error> {
+        round_trip_test(&3.14f64)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Pretty straightforward. I didn't put a DBL register in the integration fixture bitfile because the roboRIO doesn't support them IIRC, but I'm pretty confident they'll work as the SGL register does.