### PR TITLE
Use const-generic-sized arrays for FPGA communication instead of BitVecs

### DIFF
--- a/ni-fpga/src/datatype.rs
+++ b/ni-fpga/src/datatype.rs
@@ -1,6 +1,6 @@
 use bitvec::prelude::*;
 
-use crate::Error;
+use crate::errors::Error;
 
 #[cfg(target_endian = "little")]
 pub type FpgaBits = BitSlice<Msb0, u8>;

--- a/ni-fpga/src/errors.rs
+++ b/ni-fpga/src/errors.rs
@@ -4,6 +4,7 @@ use crate::status::Status;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum Error {
+    #[allow(clippy::upper_case_acronyms)]
     #[error("an FPGA operation failed: {0}")]
     FPGA(Status),
     #[error("the FPGA returned an invalid enum discriminant: {0}")]

--- a/ni-fpga/src/errors.rs
+++ b/ni-fpga/src/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::Status;
+use crate::status::Status;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum Error {

--- a/ni-fpga/src/fxp.rs
+++ b/ni-fpga/src/fxp.rs
@@ -1,6 +1,7 @@
 use crate::datatype::{Datatype, FpgaBits};
 use crate::errors::Error;
 
+#[allow(clippy::upper_case_acronyms)]
 pub struct FXP<const WORD_LENGTH: u8, const INTEGER_LENGTH: u8, const SIGNED: bool>(u64);
 
 pub type SignedFXP<const WORD_LENGTH: u8, const INTEGER_LENGTH: u8> =

--- a/ni-fpga/src/fxp.rs
+++ b/ni-fpga/src/fxp.rs
@@ -1,6 +1,5 @@
-use crate::Datatype;
-use crate::Error;
-use crate::FpgaBits;
+use crate::datatype::{Datatype, FpgaBits};
+use crate::errors::Error;
 
 pub struct FXP<const WORD_LENGTH: u8, const INTEGER_LENGTH: u8, const SIGNED: bool>(u64);
 

--- a/ni-fpga/src/lib.rs
+++ b/ni-fpga/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(const_evaluatable_checked)]
 #![feature(const_generics)]
 #![feature(maybe_uninit_uninit_array)]
 
@@ -9,6 +10,7 @@ pub mod fxp;
 mod session;
 mod status;
 
+// Keep these for backwards compatibility, but don't use them internally
 pub use datatype::{Datatype, FpgaBits};
 pub use errors::Error;
 pub type Offset = ffi::Offset;

--- a/ni-fpga/src/status.rs
+++ b/ni-fpga/src/status.rs
@@ -131,8 +131,8 @@ impl From<ffi::Status> for Status {
     }
 }
 
-impl Into<ffi::Status> for Status {
-    fn into(self) -> ffi::Status {
-        self.0
+impl From<Status> for ffi::Status {
+    fn from(status: Status) -> Self {
+        status.0
     }
 }


### PR DESCRIPTION
A fun change that should avoid some runtime BitVec operations.
Unit tests pass.
Integration tests pass.
```
admin@roboRIO-1337-FRC:~# ./integration
read plain U8...passed
read plain U16...passed
read plain U32...passed
read plain U64...passed
read plain I8...passed
read plain I16...passed
read plain I32...passed
read plain I64...passed
read SGL...passed
read unsigned FXP...passed
read unsigned FXP...passed
read true bool...passed
read false bool...passed
read bool array...passed
read cluster...passed
read cluster array...failed: [TestCluster { b: false, u: 2 }, TestCluster { b: true, u: 14592 }] (actual) != [TestCluster { b: true, u: 255 }, TestCluster { b: false, u: 1337 }] (expected)
```