### PR TITLE
Add license key to Cargo.toml

### DIFF
--- a/ni-fpga-macros/Cargo.toml
+++ b/ni-fpga-macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "ni-fpga-macros"
 version = "1.0.1"
 authors = ["Connor Worley <connorbworley@gmail.com>"]
 edition = "2018"
+license = "MIT"
 license-file = "LICENSE.md"
 description = "Macros to be used with the ni-fpga crate."
 repository = "https://github.com/first-rust-competition/ni-fpga-rs"

--- a/ni-fpga/Cargo.toml
+++ b/ni-fpga/Cargo.toml
@@ -3,6 +3,7 @@ name = "ni-fpga"
 version = "1.4.1"
 authors = ["Connor Worley <connorbworley@gmail.com>"]
 edition = "2018"
+license = "MIT"
 license-file = "LICENSE.md"
 description = "Safe Rust interface to NI FPGAs with FXP support."
 readme = "README.md"


### PR DESCRIPTION
crates.io currently shows the license for this crate as `non-standard`:

![image](https://user-images.githubusercontent.com/128854/165085551-05aa854b-19a6-48ff-9cba-5763904f30d4.png)
